### PR TITLE
chore: publish with attestation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Build and publish package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write 
 
     steps:
       - name: Checkout
@@ -51,6 +53,4 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: ${{ env.DIST_DIR }}


### PR DESCRIPTION
Based on [attestation warnings in the release pipeline](https://github.com/equinix/equinix-sdk-python/actions/runs/12290045589), this PR removes the username and password combo, as advised in the GHA warnings and here: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing

I've added the Trusted Publisher Management publisher profile for GitHub to the Pypi project.
https://pypi.org/manage/project/equinix/settings/publishing/

I'm leaving the token credential in GHA Secrets, for now, so that we can revert this PR and take the alternate approach of disabling attestation if there are additional hurdles in the publishing phase.