### PR TITLE
chore(ci): only publish to PyPI if a new release was created

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,5 @@
 name: Generate Next Release
 # This workflow will generate changelog and release notes.
-# Source: https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/.github/workflows/release.yml
 
 on:
   workflow_dispatch:
@@ -9,10 +8,43 @@ env:
   DIST_DIR: dist
 jobs:
   release:
-    name: Build and publish package
+    name: Create next release
     runs-on: ubuntu-latest
+
+    outputs:
+      new_release_published: ${{ steps.release.outputs.new_release_published }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Create GitHub release
+        id: release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/exec@6.0.3
+            @semantic-release/git@10.0.0
+            conventional-changelog-conventionalcommits@8.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: equinix-labs@auto-commit-workflow
+          GIT_AUTHOR_EMAIL: bot@equinix.noreply.github.com
+          GIT_COMMITTER_NAME: equinix-labs@auto-commit-workflow
+          GIT_COMMITTER_EMAIL: bot@equinix.noreply.github.com
+          RELEASE_REQUESTER: "@${{ github.event.sender.login }}"
+
+  publish:
+    name: Publish artifacts
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+
     permissions:
-      id-token: write 
+      id-token: write
 
     steps:
       - name: Checkout
@@ -30,27 +62,11 @@ jobs:
         run: |
           python -m pip install --upgrade build
 
-      - name: Create GitHub release
-        uses: cycjimmy/semantic-release-action@v4
-        with:
-          semantic_version: 19.0.5
-          extra_plugins: |
-            @semantic-release/exec@6.0.3
-            @semantic-release/git@10.0.0
-            conventional-changelog-conventionalcommits@4.6.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: equinix-labs@auto-commit-workflow
-          GIT_AUTHOR_EMAIL: bot@equinix.noreply.github.com
-          GIT_COMMITTER_NAME: equinix-labs@auto-commit-workflow
-          GIT_COMMITTER_EMAIL: bot@equinix.noreply.github.com
-          RELEASE_REQUESTER: "@${{ github.event.sender.login }}"
-
       - name: Build package
         run: |
           python -m build --sdist --wheel --outdir ${{ env.DIST_DIR }} .
 
-      - name: Publish package
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ${{ env.DIST_DIR }}


### PR DESCRIPTION
The semantic release GitHub Action will skip creating a new GitHub release if there are no new releasable changes.  This is expected, but the release workflow assumed that there was always a new release to publish to PyPI.

This PR updates the release workflow to move the PyPI publish steps to a separate job that will only run if the release job successfully creates a new release.