### PR TITLE
chore: use consistent working directory for all containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ USER_AGENT=${GIT_REPO}/${PACKAGE_VERSION}
 OPENAPI_IMAGE_TAG=v7.10.0
 OPENAPI_IMAGE=openapitools/openapi-generator-cli:${OPENAPI_IMAGE_TAG}
 CRI=docker # nerdctl
-OPENAPI_GENERATOR=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/local ${OPENAPI_IMAGE}
+OPENAPI_GENERATOR=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/workdir -w /workdir ${OPENAPI_IMAGE}
 SPEC_FETCHER=${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} -v $(CURDIR):/workdir --entrypoint sh mikefarah/yq:4.30.8 script/download_spec.sh
 
 SPEC_BASE_DIR=spec/services

--- a/Makefile.fabricv4
+++ b/Makefile.fabricv4
@@ -48,12 +48,12 @@ codegen:
 		-p packageVersion=${PACKAGE_VERSION} \
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO} \
-		-c /local/config/openapi-generator.json \
-		-t /local/${TEMPLATE_DIR} \
-		-o /local/ \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-c config/openapi-generator.json \
+		-t ${TEMPLATE_DIR} \
+		-o . \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
 
 validate:
 	${OPENAPI_GENERATOR} validate \
 		--recommend \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}

--- a/Makefile.metalv1
+++ b/Makefile.metalv1
@@ -32,13 +32,13 @@ patch:
 	# to use v7.4.0 of openapi-generator to merge the
 	# spec in order to avoid introducing duplicate models
 	${CRI} run --rm -u ${CURRENT_UID}:${CURRENT_GID} \
-	    -v $(CURDIR):/local \
+	    -v $(CURDIR):/workdir -w /workdir \
 		openapitools/openapi-generator-cli:v7.4.0 \
 		generate \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE} \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE} \
 		-g openapi-yaml \
 		-p skipOperationExample=true -p outputFile=${SPEC_ROOT_FILE} \
-		-o /local/${SPEC_PATCHED_DIR}
+		-o ${SPEC_PATCHED_DIR}
 
 	rm -rf ${SPEC_PATCHED_DIR}/.openapi-generator* \
 		   ${SPEC_PATCHED_DIR}/README.md \
@@ -68,14 +68,14 @@ codegen:
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO} \
 		`# TODO: re-enable the config file option so that generated code follows OpenAPI standards; this is only disabled to provide an upgrade path for metal-python` \
-		`# -c /local/config/openapi-generator.json` \
+		`# -c config/openapi-generator.json` \
 		`# TODO: remove this when the config file is re-enabled` \
 		-p generateSourceCodeOnly=true \
-		-t /local/${TEMPLATE_DIR} \
-		-o /local/ \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-t ${TEMPLATE_DIR} \
+		-o . \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
 
 validate:
 	${OPENAPI_GENERATOR} validate \
 		--recommend \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}

--- a/templates/Makefile.sdk
+++ b/templates/Makefile.sdk
@@ -47,12 +47,12 @@ codegen:
 		-p packageVersion=${PACKAGE_VERSION} \
 		--git-user-id ${GIT_ORG} \
 		--git-repo-id ${GIT_REPO} \
-		-c /local/config/openapi-generator.json \
-		-t /local/${TEMPLATE_DIR} \
-		-o /local/ \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-c config/openapi-generator.json \
+		-t ${TEMPLATE_DIR} \
+		-o . \
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
 
 validate:
 	${OPENAPI_GENERATOR} validate \
 		--recommend \
-		-i /local/${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}
+		-i ${SPEC_PATCHED_DIR}/${SPEC_ROOT_FILE}


### PR DESCRIPTION
This updates the openapi-generator commands so that the mounting location and working directory for the openapi-generator container are consistent with our other containers.  This removes the need to prefix repository file paths with `/local/` for commands that run inside the openapi-generator container. 