### PR TITLE
chore(ci): fix PR test workflow

### DIFF
--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -66,5 +66,5 @@ jobs:
         run: make testall
         working-directory: .ansible/collections/ansible_collections/equinix/cloud
         env:
-          METAL_API_TOKEN: ${{ secrets.METAL_API_TOKEN }}
+          METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
 

--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: .ansible/collections/ansible_collections/equinix/cloud
 
       - name: install cloned Python SDK
-        run: python3 -m pip install ./equinix_metal
+        run: python3 -m pip install .
 
 
       - name: replace existing keys


### PR DESCRIPTION
This fixes the install path for the PR validation workflow so that it can successfully install a modified Equinix Python SDK from local files before running Ansible collection end-to-end tests.  The Metal token environment variable is also updated to match what is expected by the Ansible collection test suite.