### PR TITLE
chore(ci): pass in dedicated connection ID for Ansible tests

### DIFF
--- a/.github/workflows/ansible-tests-pr.yml
+++ b/.github/workflows/ansible-tests-pr.yml
@@ -13,6 +13,9 @@ permissions:
   pull-requests: read
   contents: read
 
+env:
+  COLLECTION_PATH: .ansible/collections/ansible_collections/equinix/cloud
+
 jobs:
   authorize:
     environment:
@@ -47,24 +50,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: equinix-labs/ansible-collection-equinix
-          path: .ansible/collections/ansible_collections/equinix/cloud
+          path: ${{ env.COLLECTION_PATH }}
           ref: main
 
       - name: install dependencies of ansible collection
         run: pip3 install -r requirements-dev.txt -r requirements.txt
-        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+        working-directory: ${{ env.COLLECTION_PATH }}
+
+      - name: install collection
+        run: make install
+        working-directory: ${{ env.COLLECTION_PATH }}
 
       - name: install cloned Python SDK
         run: python3 -m pip install .
 
-
       - name: replace existing keys
         run: rm -rf ~/.ansible/test && mkdir -p ~/.ansible/test && ssh-keygen -m PEM -q -t rsa -N '' -f ~/.ansible/test/id_rsa
-        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+        working-directory: ${{ env.COLLECTION_PATH }}
 
       - name: run tests in ansible collection directory
         run: make testall
-        working-directory: .ansible/collections/ansible_collections/equinix/cloud
+        working-directory: ${{ env.COLLECTION_PATH }}
         env:
           METAL_AUTH_TOKEN: ${{ secrets.METAL_AUTH_TOKEN }}
-
+          ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID: ${{ secrets.ANSIBLE_ACC_METAL_DEDICATED_CONNECTION_ID }}


### PR DESCRIPTION
The Ansible end-to-end test for the virtual circuit module has a bug, which causes the test to be skipped only partially when a dedicated Metal connection ID is not specified.  Since the PR workflow in this SDK is meant to replicate the coverage provided by the tests in the Ansible collection, this adds the missing dedicated Metal connection ID so that the tests run as expected.