### PR TITLE
docs: warn about removal of Metal code ahead of Equinix Metal EoL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Equinix Python SDK
 
+> [!WARNING]
+> With the upcoming EoL of Equinix Metal on June 30, 2026, support for the Metal (`metalv1`) service will be removed from this SDK.
+
 [![Release](https://img.shields.io/github/v/release/equinix/equinix-sdk-python)](https://github.com/equinix/equinix-sdk-python/releases/latest)
 [![PyPi](https://img.shields.io/pypi/v/equinix)](https://pypi.org/project/equinix)
 


### PR DESCRIPTION
Adds a warning notice to the README about the upcoming removal of the Metal (`metalv1`) service from this SDK, ahead of the Equinix Metal EoL on June 30, 2026.

Resolves BMS-1987.